### PR TITLE
Avoid the use of important in multi-column dropdown menues

### DIFF
--- a/stragula.less
+++ b/stragula.less
@@ -173,8 +173,6 @@ table a:not(.btn),
 	box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
 	z-index: 1;
 	border-radius: 0px;
-	left: auto;
-	right: 0;
 	border-top: 5px solid @color2;
 	/* Links inside the dropdown */
 	a {
@@ -229,9 +227,16 @@ table a:not(.btn),
 
 @media only screen and (max-width: 480px) {
 	.dropdown-content {
-		left: -100% !important;
-		right: auto !important;
-		column-gap: 0px !important;
+		left: -100%;
+		right: auto;
+		column-gap: 0px;
+	}
+}
+
+@media only screen and (min-width: 480px) {
+	.dropdown-content {
+		left: auto;
+		right: 0;
 	}
 }
 


### PR DESCRIPTION
@kghbln, after read [some posts in StackOverflow](https://stackoverflow.com/search?q=%21important+css+media+queries) I have two theories:

1. Maybe something in the cascade-hierarchy is overlapping the media query, but this is strange because the priority is always the last specification, as we have in the code: first the default and then the media query.
2. Maybe is necessary to use another rule to [specify the `min-width`](https://stackoverflow.com/questions/24202078/sass-css-media-queries-prone-to-breaking).

I made the change based on the second theory. Could you use this code to check if it works fine without `!important`? **Note** that you have to remove the `left` and `right` from `.dropdown-content`, to be just in media queries.

For the user manual, if tomorrow I have a bit of time to dedicate to it, I will make it.