### PR TITLE
Fix for multicolumns user manual menu in devices with 480px or less

### DIFF
--- a/stragula.less
+++ b/stragula.less
@@ -720,11 +720,11 @@ table.smworgtable-v2-toc {
     column-rule: 1px solid lightblue;
 }
 
-@media query screen (max-width: 480px) {
+@media only screen and (max-width: 480px) {
 	.user-manual {
-		-webkit-column-count: 2;
-    -moz-column-count: 2;
-    column-count: 2;
+		-webkit-column-count: 2 !important;
+		-moz-column-count: 2 !important;
+		column-count: 2 !important;
 	}
 }
 

--- a/stragula.less
+++ b/stragula.less
@@ -719,6 +719,15 @@ table.smworgtable-v2-toc {
     -moz-column-rule: 1px solid lightblue;
     column-rule: 1px solid lightblue;
 }
+
+@media query screen (max-width: 480px) {
+	.user-manual {
+		-webkit-column-count: 2;
+    -moz-column-count: 2;
+    column-count: 2;
+	}
+}
+
 .admin-manual {
     -webkit-column-count: 2;
     -moz-column-count: 2;


### PR DESCRIPTION
In reference to #11 and #17, I made this fix to change the three columns of the user manual menu to two columns. It should work without `!important` and any additional media query, but as we seen in #17, maybe could be necessary to make another trick like use `!important` or made another media query, although this isn't confirmed that work per #20.

Test it in live, @kghbln, and tell me if it works only with this code or if it's necessary to use one of the both tricks I mentioned.

Regards,
Iván