### PR TITLE
Catlinks at the bottom of all the content and fix the overlapped footer

### DIFF
--- a/stragula.less
+++ b/stragula.less
@@ -765,3 +765,11 @@ table.smworgtable-v2-toc {
 		border-radius: 3px;
 	}
 }
+
+/**
+ * Trick to keep the categories section at the bottom of all content
+ */
+
+#catlinks {
+	clear: right;
+}

--- a/stragula.less
+++ b/stragula.less
@@ -566,7 +566,6 @@ ul.lqt-thread-toolbar-commands {
  */
 .smwofootergrid.container {
 	position: absolute;
-  	bottom: 0;
   	width: 100%;
   	/* Set the fixed height of the footer here */
   	height: 125px;

--- a/stragula.less
+++ b/stragula.less
@@ -566,6 +566,7 @@ ul.lqt-thread-toolbar-commands {
  */
 .smwofootergrid.container {
 	position: absolute;
+	bottom: 0;
   	width: 100%;
   	/* Set the fixed height of the footer here */
   	height: 125px;


### PR DESCRIPTION
Trying to solve #9, I think one solution might be to use this little snippet (first commit):

```css
#catlinks {
	clear: right;
}
```

I added at the bottom of the stylesheet but if you think it should be in another place, you can replace it without problems (my PRs allow edits from maintainers).

But, in the another hand, I detect one problem with the footer when it is in a mobile device. This is the current result (and error):

![smwcon spring 2012 semantic mediawiki org 1](https://user-images.githubusercontent.com/8690921/37256474-28da3ab0-2553-11e8-80a9-e12527861b91.png)

And this is how it looks after disable the `bottom: 0` in `.smwofootergrid.container`, that I deleted in the second commit of this PR:

![smwcon spring 2012 semantic mediawiki org 2](https://user-images.githubusercontent.com/8690921/37256500-70faa8e8-2553-11e8-92ad-651095c89546.png)

@kghbln, could we test in smw.o? I hope it works and solved both issues.

Regards,
Iván